### PR TITLE
Add root level is_relevant helper

### DIFF
--- a/is_relevant.py
+++ b/is_relevant.py
@@ -1,0 +1,9 @@
+from llm_prompt_builders.prompts.is_relevant import (
+    DEFAULT_POSITIVE_CRITERIA_IS_RELEVANT,
+    get_is_relevant,
+)
+
+__all__ = [
+    "DEFAULT_POSITIVE_CRITERIA_IS_RELEVANT",
+    "get_is_relevant",
+]

--- a/src/llm_prompt_builders/__init__.py
+++ b/src/llm_prompt_builders/__init__.py
@@ -1,7 +1,7 @@
 """OHDSI llm_prompt_builders package root."""
 
 # ---- static string so Hatchling can read the version -----------------------
-__version__ = "0.1.9"               # ⬅️  bump for each release
+__version__ = "0.2.0"
 # ---------------------------------------------------------------------------
 
 from importlib.metadata import version, PackageNotFoundError

--- a/src/llm_prompt_builders/prompts/__init__.py
+++ b/src/llm_prompt_builders/prompts/__init__.py
@@ -1,0 +1,60 @@
+"""
+llm_prompt_builders/__init__.py
+Dynamic function re-exporter.
+"""
+
+import inspect
+import importlib
+import pkgutil
+from types import ModuleType
+from typing import Callable, Dict, List
+
+__all__: List[str] = []          # populated at import time
+_functions: Dict[str, Callable] = {}  # optional: keep a registry if you need it
+
+
+def _load_all_functions() -> None:
+    """
+    Walk every sub-module inside the current package, import it,
+    and pull any *top-level* functions up into this namespace.
+    """
+    pkg_name = __name__
+    pkg = importlib.import_module(pkg_name)
+
+    for _, mod_name, is_pkg in pkgutil.walk_packages(
+        pkg.__path__,  prefix=f"{pkg_name}."
+    ):
+        if is_pkg:
+            # Skip sub-packages; walk_packages will recurse automatically.
+            continue
+
+        try:
+            module: ModuleType = importlib.import_module(mod_name)
+        except Exception as err:
+            # Optionally log so failures don’t kill the import chain.
+            # print(f"⚠️  Skipped {mod_name}: {err}")
+            continue
+
+        for obj_name, obj in inspect.getmembers(module, inspect.isfunction):
+            # Skip dunder helpers, etc.  Tighten/loosen as desired.
+            if obj_name.startswith("_"):
+                continue
+
+            # Don’t overwrite if a name already exists.
+            if obj_name in globals():
+                # Optionally warn or raise.
+                continue
+
+            globals()[obj_name] = obj
+            __all__.append(obj_name)
+            _functions[obj_name] = obj
+
+
+# Do the work once at import time.
+_load_all_functions()
+
+# Optional: provide a lazy fallback so unknown attributes are still searched.
+def __getattr__(name: str):
+    if name in _functions:
+        return _functions[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/llm_prompt_builders/prompts/__init__.py
+++ b/src/llm_prompt_builders/prompts/__init__.py
@@ -74,4 +74,13 @@ for _file in _prompts_dir.glob("*.py"):
     _full  = f"{__name__}.prompts.{_alias}" # e.g. "llm_prompt_builders.prompts.is_relevant"
     _sys.modules.setdefault(_alias, import_module(_full))
 
-del _file, _alias, _full, _prompts_dir, import_module, Path, _sys
+for _name in (
+    "_file",
+    "_alias",
+    "_full",
+    "_prompts_dir",
+    "import_module",
+    "Path",
+    "_sys",
+):
+    globals().pop(_name, None)        # quietly ignore if the symbol never existed

--- a/src/llm_prompt_builders/prompts/is_relevant.py
+++ b/src/llm_prompt_builders/prompts/is_relevant.py
@@ -81,7 +81,14 @@ def get_is_relevant(
 
     header = textwrap.dedent(
         f"""\
-        TASK — Read one paragraph as an expert informatician.\n\n        The purpose is {purpose}.\n        The text is from {data_origin}.\n\n        Return {{ \"is_relevant\": true }} **only if**:\n          • at least one *Look‑for* item appears in the paragraph, **and**\n          • none of the *Should‑NOT‑contain* items appear (if any are defined).\n\n        Otherwise return {{ \"is_relevant\": false }}.\n\n        Return false as well if the paragraph is only background, discussion, or a purely prospective randomized trial with no secondary‑data algorithm.\n\n        Use lowercase booleans and nothing else.\n"""
+        TASK — Read one paragraph as an expert informatician.\n\n
+        The purpose is {purpose}.\n
+        The text is from {data_origin}.\n\n
+        Return {{ \"is_relevant\": true }} **only if**:\n
+        • at least one *Look‑for* item appears in the paragraph, **and**\n
+        • none of the *Should‑NOT‑contain* items appear (if any are defined).\n\n
+        Otherwise return {{ \"is_relevant\": false }}.\n\n
+        Use lowercase booleans and nothing else.\n"""
     )
 
     sections: List[str] = [_build_criteria_section("Look‑for (any of)", pos)]

--- a/src/llm_prompt_builders/prompts/is_relevant.py
+++ b/src/llm_prompt_builders/prompts/is_relevant.py
@@ -28,7 +28,7 @@ except ModuleNotFoundError:  # pragma: no cover – keeps the script self‑cont
 ###############################################################################
 # Default *positive* criteria – actionable details
 ###############################################################################
-DEFAULT_POSITIVE_CRITERIA: List[str] = [
+DEFAULT_POSITIVE_CRITERIA_IS_RELEVANT: List[str] = [
     "data source or care setting",
     "demographic filter (age, sex, insurance, etc.)",
     "entry/index event (diagnosis/procedure/drug/lab code, ≥ n codes, look‑back, first/second hit, etc.)",
@@ -55,7 +55,7 @@ def _build_criteria_section(label: str, items: Sequence[str]) -> str:
 # Public API
 ###############################################################################
 
-def build_is_relevant_prompt(
+def get_is_relevant(
     data_origin: str,
     purpose: str,
     positive_criteria: Sequence[str] | None = None,
@@ -76,7 +76,7 @@ def build_is_relevant_prompt(
         Items that *invalidate* relevance.  If *None* or empty, this section is
         omitted and only the *positive* test applies.
     """
-    pos = list(positive_criteria or DEFAULT_POSITIVE_CRITERIA)
+    pos = list(positive_criteria or DEFAULT_POSITIVE_CRITERIA_IS_RELEVANT)
     neg = list(negative_criteria or [])
 
     header = textwrap.dedent(
@@ -100,6 +100,11 @@ def build_is_relevant_prompt(
 # Re‑exports
 # ---------------------------------------------------------------------------
 __all__ = [
-    "DEFAULT_POSITIVE_CRITERIA",
-    "build_is_relevant_prompt",
+    "DEFAULT_POSITIVE_CRITERIA_IS_RELEVANT",
+    "get_is_relevant",
 ]
+
+from llm_prompt_builders.prompts.is_relevant import (  # type: ignore
+    get_is_relevant as _impl_build,
+    DEFAULT_POSITIVE_CRITERIA_IS_RELEVANT as _DEFAULT,
+)

--- a/src/llm_prompt_builders/prompts/is_relevant.py
+++ b/src/llm_prompt_builders/prompts/is_relevant.py
@@ -1,0 +1,124 @@
+"""is_relevant.py
+A tiny helper utility built on top of the `llm_prompt_builders` toolkit that
+constructs a reusable prompt asking an LLM to decide whether a paragraph
+contains *actionable* information for building or validating a computable
+cohort/phenotype.
+
+The generated prompt instructs the model to answer **only** with a JSON object
+of the form:
+
+    { "is_relevant": true }
+
+or
+
+    { "is_relevant": false }
+
+Booleans must stay lowercase, as required by the downstream evaluator.
+"""
+from __future__ import annotations
+
+import textwrap
+from typing import List, Sequence
+
+try:
+    # `llm_prompt_builders` offers a tiny functional DSL for composing prompt
+    # fragments.  If it is available we will use its `chain` accelerator for a
+    # cleaner construction; otherwise we gracefully fall back to plain string
+    # concatenation so that the module still works without the extra
+    # dependency.
+    from llm_prompt_builders.accelerators.chain import chain as _chain  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover – makes the script self‑contained
+    _chain = None
+
+###############################################################################
+# Canonical *actionable detail* bullets
+###############################################################################
+DEFAULT_ACTIONABLE_BULLETS: List[str] = [
+    "data source or care setting",
+    "demographic filter (age, sex, insurance, etc.)",
+    "entry/index event (diagnosis/procedure/drug/lab code, ≥ n codes, look‑back, first/second hit, etc.)",
+    "extra inclusion / exclusion rule",
+    "wash‑out or continuous‑enrollment window",
+    "exit/censor rule",
+    "outcome‑finding algorithm",
+    "explicit medical codes (ICD, SNOMED, CPT, RxNorm, ATC, LOINC …)",
+    "follow‑up / time‑at‑risk spec",
+    "comparator or exposure logic",
+    "validation stats (PPV, sensitivity)",
+    "attrition counts",
+]
+
+
+def build_actionable_details_section(details: Sequence[str] | None = None) -> str:
+    """Return the *Actionable details* subsection of the prompt.
+
+    Parameters
+    ----------
+    details
+        A custom list of bullet strings.  When *None*, the canonical
+        :pydata:`DEFAULT_ACTIONABLE_BULLETS` is used.
+    """
+    bullets = details or DEFAULT_ACTIONABLE_BULLETS
+    bullet_lines = "\n".join(f"* {b}" for b in bullets)
+    return f"Actionable details = any of\n\n{bullet_lines}\n"
+
+
+def build_is_relevant_prompt(
+    data_origin: str,
+    purpose: str,
+    details: Sequence[str] | None = None,
+) -> str:
+    """Compose the final prompt string.
+
+    The helper can be used *stand‑alone* or combined with the higher‑level
+    pieces that ship with *llm_prompt_builders*.
+
+    Parameters
+    ----------
+    data_origin
+        Where the paragraph comes from – e.g. "routine health data (claims, EHR,
+        registry)".  This string is interpolated verbatim in the instructions.
+    purpose
+        A concise description of why we care – e.g. "building or validating a
+        computable cohort/phenotype".
+    details
+        Optional custom bullet list replacing the defaults.
+
+    Returns
+    -------
+    str
+        A fully‑formed prompt ready to be sent to the LLM.
+    """
+    header = textwrap.dedent(
+        f"""\
+        TASK — Read the text as an expert informatician. Think through the meaning of the content step by step. \n
+        The purpose if {purpose}. \n
+        The text is from {data_origin}.\n
+        Return {{ \"is_relevant\": true }} if the paragraph gives actionable details. Otherwise return {{ \"is_relevant\": false }}. Use lowercase booleans and nothing else.\n\n"""
+    )
+
+    actionable = build_actionable_details_section(details)
+
+    footer = textwrap.dedent(
+        """\
+        \n\n"""
+    )
+
+    parts = [header, actionable, footer]
+
+    # Prefer the composable DSL when available.
+    if _chain is not None:  # pragma: no cover
+        return _chain(parts)
+
+    # Fallback: naïve join with a single blank line as separator.
+    return "\n".join(parts).strip()
+
+
+# ---------------------------------------------------------------------------
+# Public re‑exports
+# ---------------------------------------------------------------------------
+__all__ = [
+    "DEFAULT_ACTIONABLE_BULLETS",
+    "build_actionable_details_section",
+    "build_is_relevant_prompt",
+]

--- a/tests/prompts/test_is_relevant.py
+++ b/tests/prompts/test_is_relevant.py
@@ -14,7 +14,7 @@ import pytest
 
 from is_relevant import (
     DEFAULT_ACTIONABLE_BULLETS,
-    build_is_relevant_prompt,
+    get_is_relevant,
 )
 
 ###############################################################################
@@ -32,7 +32,7 @@ def _strip_ws(text: str) -> str:
 
 def test_default_prompt_contains_mandatory_fragments() -> None:
     """The default prompt must include both JSON answers & all canonical bullets."""
-    prompt = build_is_relevant_prompt(
+    prompt = get_is_relevant(
         data_origin="routine health data (claims, EHR, registry, etc.)",
         purpose="building or validating a computable cohort/phenotype",
     )
@@ -54,7 +54,7 @@ def test_custom_actionable_details_override_defaults() -> None:
         "signal‑noise ratio window",
         "hyper‑specific eligibility criterion",
     ]
-    prompt = build_is_relevant_prompt(
+    prompt = get_is_relevant(
         data_origin="claims data",
         purpose="validating a phenotype",
         details=custom_details,
@@ -71,7 +71,7 @@ def test_custom_actionable_details_override_defaults() -> None:
 
 def test_prompt_is_plain_string() -> None:
     """Regardless of the optional llm‑prompt‑builders dependency, output is str."""
-    prompt = build_is_relevant_prompt("claims", "cohort")
+    prompt = get_is_relevant("claims", "cohort")
     assert isinstance(prompt, str)
 
 
@@ -80,7 +80,7 @@ def test_prompt_is_plain_string() -> None:
 ###############################################################################
 
 def test_prompt_final_instruction() -> None:
-    prompt = build_is_relevant_prompt("claims", "cohort")
+    prompt = get_is_relevant("claims", "cohort")
     assert prompt.strip().endswith("Use lowercase booleans and nothing else."), (
         "Prompt must end with the lowercase‑boolean instruction",
     )

--- a/tests/prompts/test_is_relevant.py
+++ b/tests/prompts/test_is_relevant.py
@@ -13,7 +13,7 @@ from typing import List
 import pytest
 
 from is_relevant import (
-    DEFAULT_ACTIONABLE_BULLETS,
+    DEFAULT_POSITIVE_CRITERIA_IS_RELEVANT,
     get_is_relevant,
 )
 
@@ -44,7 +44,7 @@ def test_default_prompt_contains_mandatory_fragments() -> None:
     assert "{ \"is_relevant\": false }" in prompt_nows
 
     # Every canonical bullet should appear verbatim preceded by a bullet star.
-    for bullet in DEFAULT_ACTIONABLE_BULLETS:
+    for bullet in DEFAULT_POSITIVE_CRITERIA_IS_RELEVANT:
         assert f"* {bullet}" in prompt, f"Missing bullet: {bullet}"
 
 
@@ -65,7 +65,7 @@ def test_custom_actionable_details_override_defaults() -> None:
         assert f"* {bullet}" in prompt
 
     # … while *none* of the canonical ones appear.
-    for default in DEFAULT_ACTIONABLE_BULLETS:
+    for default in DEFAULT_POSITIVE_CRITERIA_IS_RELEVANT:
         assert f"* {default}" not in prompt
 
 

--- a/tests/prompts/test_is_relevant.py
+++ b/tests/prompts/test_is_relevant.py
@@ -1,0 +1,86 @@
+"""tests/test_is_relevant.py
+Unit tests for the *is_relevant* prompt‑builder helper.
+
+Run with pytest:
+
+    pytest -q
+"""
+from __future__ import annotations
+
+import re
+from typing import List
+
+import pytest
+
+from is_relevant import (
+    DEFAULT_ACTIONABLE_BULLETS,
+    build_is_relevant_prompt,
+)
+
+###############################################################################
+# Fixtures & helpers
+###############################################################################
+
+def _strip_ws(text: str) -> str:
+    """Normalize whitespace for robust substring checks."""
+    return re.sub(r"\s+", " ", text).strip()
+
+
+###############################################################################
+# Tests
+###############################################################################
+
+def test_default_prompt_contains_mandatory_fragments() -> None:
+    """The default prompt must include both JSON answers & all canonical bullets."""
+    prompt = build_is_relevant_prompt(
+        data_origin="routine health data (claims, EHR, registry, etc.)",
+        purpose="building or validating a computable cohort/phenotype",
+    )
+
+    prompt_nows = _strip_ws(prompt)
+
+    # Mandatory JSON answer snippets
+    assert "{ \"is_relevant\": true }" in prompt_nows
+    assert "{ \"is_relevant\": false }" in prompt_nows
+
+    # Every canonical bullet should appear verbatim preceded by a bullet star.
+    for bullet in DEFAULT_ACTIONABLE_BULLETS:
+        assert f"* {bullet}" in prompt, f"Missing bullet: {bullet}"
+
+
+def test_custom_actionable_details_override_defaults() -> None:
+    """Supplying *details* replaces (does not append to) the default bullets."""
+    custom_details: List[str] = [
+        "signal‑noise ratio window",
+        "hyper‑specific eligibility criterion",
+    ]
+    prompt = build_is_relevant_prompt(
+        data_origin="claims data",
+        purpose="validating a phenotype",
+        details=custom_details,
+    )
+
+    # Custom bullets must be present …
+    for bullet in custom_details:
+        assert f"* {bullet}" in prompt
+
+    # … while *none* of the canonical ones appear.
+    for default in DEFAULT_ACTIONABLE_BULLETS:
+        assert f"* {default}" not in prompt
+
+
+def test_prompt_is_plain_string() -> None:
+    """Regardless of the optional llm‑prompt‑builders dependency, output is str."""
+    prompt = build_is_relevant_prompt("claims", "cohort")
+    assert isinstance(prompt, str)
+
+
+###############################################################################
+# Optional: quick sanity check that the prompt ends with the strict guidance.
+###############################################################################
+
+def test_prompt_final_instruction() -> None:
+    prompt = build_is_relevant_prompt("claims", "cohort")
+    assert prompt.strip().endswith("Use lowercase booleans and nothing else."), (
+        "Prompt must end with the lowercase‑boolean instruction",
+    )

--- a/tests/prompts/test_is_relevant.py
+++ b/tests/prompts/test_is_relevant.py
@@ -1,51 +1,54 @@
-"""Updated pytest suite for llm_prompt_builders.prompts.is_relevant
+"""pytest suite for the public API of `is_relevant.py`
 
-These tests exercise the public contract of `build_is_relevant_prompt` as well
-as the exported defaults.  They no longer rely on the legacy top‑level
-`is_relevant` module that was removed during the package re‑org.
+These tests exercise the *current* helper that lives at the project root and
+exports `DEFAULT_POSITIVE_CRITERIA_IS_RELEVANT` and `get_is_relevant`.
 """
 
 from __future__ import annotations
 
-import pytest
-
-from llm_prompt_builders.prompts import is_relevant as ir
+import is_relevant as ir
 
 
-def test_default_positive_criteria_non_empty() -> None:
-    """The default list of positive criteria should be a non‑empty list."""
-    assert isinstance(ir.DEFAULT_POSITIVE_CRITERIA, list)
-    assert ir.DEFAULT_POSITIVE_CRITERIA, "Expected DEFAULT_POSITIVE_CRITERIA to be non‑empty"
+def test_default_criteria_non_empty() -> None:
+    """Default positive criteria list must exist and be non-empty."""
+    assert isinstance(ir.DEFAULT_POSITIVE_CRITERIA_IS_RELEVANT, list)
+    assert ir.DEFAULT_POSITIVE_CRITERIA_IS_RELEVANT, "Expected at least one default criterion"
 
 
 def test_prompt_contains_origin_and_purpose() -> None:
-    """Generated prompt must reflect the requested data origin and purpose."""
+    """The generated prompt should embed the data origin and purpose."""
     origin = "clinical notes"
     purpose = "detect adverse events"
+    prompt = ir.get_is_relevant(data_origin=origin, purpose=purpose)
 
-    prompt = ir.build_is_relevant_prompt(data_origin=origin, purpose=purpose)
-
-    # Case‑insensitive check to avoid surprises with capitalisation.
     prompt_lower = prompt.lower()
     assert origin.lower() in prompt_lower
     assert purpose.lower() in prompt_lower
 
 
-def test_prompt_includes_custom_criteria() -> None:
-    """Custom positive criteria should appear verbatim in the prompt."""
-    origin = "call‑centre transcripts"
+def test_custom_positive_criteria_included() -> None:
+    """All custom positive criteria must appear verbatim in the prompt."""
+    origin = "call-centre transcripts"
     purpose = "quality assurance"
-    criteria = [
-        "mentions dosage",
-        "mentions side effects",
-    ]
+    custom = ["mentions dosage", "mentions side effects"]
 
-    prompt = ir.build_is_relevant_prompt(
-        data_origin=origin,
-        purpose=purpose,
-        positive_criteria=criteria,
-    )
-
+    prompt = ir.get_is_relevant(origin, purpose, positive_criteria=custom)
     prompt_lower = prompt.lower()
-    for criterion in criteria:
-        assert criterion.lower() in prompt_lower, f"Criterion '{criterion}' missing from prompt"
+
+    for criterion in custom:
+        assert criterion.lower() in prompt_lower, f"Missing custom criterion: {criterion}"
+
+
+def test_negative_criteria_section_present() -> None:
+    """The *Should-NOT-contain* section is only present when negatives are defined."""
+    origin = "EHR"
+    purpose = "phenotype validation"
+    negatives = ["billing error", "doctor attitude"]
+
+    prompt_with_neg = ir.get_is_relevant(origin, purpose, negative_criteria=negatives)
+    assert "should-not-contain" in prompt_with_neg.lower()
+    for n in negatives:
+        assert n.lower() in prompt_with_neg.lower()
+
+    prompt_without_neg = ir.get_is_relevant(origin, purpose)
+    assert "should-not-contain" not in prompt_without_neg.lower()


### PR DESCRIPTION
## Summary
- add `is_relevant.py` at the repository root to re-export utilities from `llm_prompt_builders.prompts.is_relevant`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*