### PR TITLE
Fix is_relevant prompt and tests

### DIFF
--- a/src/llm_prompt_builders/prompts/__init__.py
+++ b/src/llm_prompt_builders/prompts/__init__.py
@@ -84,4 +84,4 @@ for _name in (
     "Path",
     "_sys",
 ):
-    globals().pop(_name, None)        # quietly ignore if the symbol never existed
+    globals().pop(_name, None)  # quietly ignore if the symbol never existed

--- a/src/llm_prompt_builders/prompts/is_relevant.py
+++ b/src/llm_prompt_builders/prompts/is_relevant.py
@@ -79,17 +79,35 @@ def get_is_relevant(
     pos = list(positive_criteria or DEFAULT_POSITIVE_CRITERIA_IS_RELEVANT)
     neg = list(negative_criteria or [])
 
-    header = textwrap.dedent(
-        f"""\
-        TASK — Read one paragraph as an expert informatician.\n\n
-        The purpose is {purpose}.\n
-        The text is from {data_origin}.\n\n
-        Return {{ \"is_relevant\": true }} **only if**:\n
-        • at least one *Look-for* item appears in the paragraph, **and**\n
-        • none of the *Should-NOT-contain* items appear (if any are defined).\n\n
-        Otherwise return {{ \"is_relevant\": false }}.\n\n
-        Use lowercase booleans and nothing else.\n"""
+    header_lines = [
+        "TASK — Read one paragraph as an expert informatician.",
+        "",
+        f"The purpose is {purpose}.",
+        f"The text is from {data_origin}.",
+        "",
+        'Return { "is_relevant": true } **only if**:',
+    ]
+
+    first_bullet = "• at least one *Look-for* item appears in the paragraph"
+    if neg:
+        first_bullet += ", **and**"
+    header_lines.append(first_bullet)
+
+    if neg:
+        header_lines.append(
+            "• none of the *Should-NOT-contain* items appear (if any are defined)."
+        )
+
+    header_lines.extend(
+        [
+            "",
+            'Otherwise return { "is_relevant": false }.',
+            "",
+            "Use lowercase booleans and nothing else.",
+        ]
     )
+
+    header = textwrap.dedent("\n".join(header_lines)) + "\n"
 
     sections: List[str] = [_build_criteria_section("Look-for (any of)", pos)]
     if neg:

--- a/tests/prompts/test_is_relevant.py
+++ b/tests/prompts/test_is_relevant.py
@@ -52,3 +52,5 @@ def test_negative_criteria_section_present() -> None:
 
     prompt_without_neg = ir.get_is_relevant(origin, purpose)
     assert "should-not-contain" not in prompt_without_neg.lower()
+    assert "look-for" in prompt_without_neg.lower()
+    assert ", **and**" not in prompt_without_neg


### PR DESCRIPTION
## Summary
- ensure is_relevant only references negative criteria when provided
- update prompts package cleanup logic
- expand tests for new prompt behaviour

## Testing
- `hatch run test:pytest --cov=llm_prompt_builders --cov-report=xml:coverage.xml` *(fails: `hatch: command not found`)*